### PR TITLE
Fix incorrect winner when rounds to win is reduced

### DIFF
--- a/server/Engine/Games/Game/GameManager.ts
+++ b/server/Engine/Games/Game/GameManager.ts
@@ -742,7 +742,8 @@ class _GameManager
 		const settings = newGame.settings;
 		const players = newGame.players;
 		const playerGuids = Object.keys(players);
-		const gameWinnerGuid = playerGuids.find(pg => (players?.[pg].wins ?? 0) >= (settings?.roundsToWin ?? 50));
+		const playerWinning = players.reduce((p,c) => {return p.score < c.score ? c: p;})
+		const gameWinnerGuid = playerGuids.find(pg => (playerWinning?.[pg].wins ?? 0) >= (settings?.roundsToWin ?? 50));
 
 		if (!gameWinnerGuid)
 		{


### PR DESCRIPTION
Fixes issue #333 where the incorrect winner is chosen after `Rounds To Win` is reduced to be equal to or less than the score of person in second place

I am not 100% sure the code is valid in rgards to pulling the PlayerGuid but should be able to be tweaked easily to work correctly